### PR TITLE
prevent nichrome casting recipe from overwriting pycoalprocessing nichrome

### DIFF
--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -606,7 +606,7 @@ end
 
 RECIPE {
     type = "recipe",
-    name = "nichrome",
+    name = "nichrome-casting",
     category = "advanced-foundry",
     enabled = false,
     energy_required = 4,


### PR DESCRIPTION
Fix for a small issue. Can the RECIPE macro maybe be made to warn on duplicates?