### PR TITLE
flip iron second process for consistency

### DIFF
--- a/prototypes/recipes/recipes-iron.lua
+++ b/prototypes/recipes/recipes-iron.lua
@@ -29,11 +29,11 @@ RECIPE {
         {type = "item", name = "processed-iron-ore", amount = 5}
     },
     results = {
-        {type = "item", name = "grade-1-iron", amount = 1},
+        {type = "item", name = "grade-1-iron", amount = 1, probability = 0.5},
         {type = "item", name = "grade-2-iron", amount = 1, probability = 0.5},
-        {type = "item", name = "grade-3-iron", amount = 1, probability = 0.5},
+        {type = "item", name = "grade-3-iron", amount = 1},
     },
-    main_product = "grade-1-iron",
+    main_product = "grade-3-iron",
     icon = "__pyraworesgraphics__/graphics/icons/processed-iron-ore-screening.png",
     icon_size = 32,
     subgroup = "py-rawores-iron",
@@ -46,12 +46,12 @@ RECIPE {
     enabled = false,
     energy_required = 3,
     ingredients = {
-        {type = "item", name = "grade-3-iron", amount = 1}
+        {type = "item", name = "grade-2-iron", amount = 1}
     },
     results = {
-        {type = "item", name = "grade-2-iron", amount = 1},
+        {type = "item", name = "grade-3-iron", amount = 1},
     },
-    main_product = "grade-2-iron",
+    main_product = "grade-3-iron",
     icon = "__pyraworesgraphics__/graphics/icons/recrush-grade-3-iron.png",
     icon_size = 32,
     subgroup = "py-rawores-iron",
@@ -64,13 +64,13 @@ RECIPE {
     enabled = false,
     energy_required = 1,
     ingredients = {
-        {type = "item", name = "grade-2-iron", amount = 1}
+        {type = "item", name = "grade-1-iron", amount = 1}
     },
     results = {
         {type = "item", name = "gravel", amount = 1, probability = 0.5},
-        {type = "item", name = "grade-1-iron", amount = 1}
+        {type = "item", name = "grade-2-iron", amount = 1}
     },
-    main_product = "grade-1-iron",
+    main_product = "grade-2-iron",
     subgroup = "py-rawores-iron",
 }:add_unlock("iron-mk02")
 
@@ -81,7 +81,7 @@ RECIPE {
     enabled = false,
     energy_required = 2,
     ingredients = {
-        {type = "item", name = "grade-1-iron", amount = 1}
+        {type = "item", name = "grade-3-iron", amount = 1}
     },
     results = {
         {type = "item", name = "iron-ore-dust", amount = 1}


### PR DESCRIPTION
I noticed that the iron 2nd process is the only flipped one from all of the other ore 2nd processes (iron: 3->2->1, other ores: 1->2->3 or vary). 

So I adjusted the recipes to be consistent with the others (basically flipped). Here are photos of proof that the recipes are really flipped. Look at line 2 to 4, line 1 only change what is the last piece to make the dust.

ORIGINAL: 
![IMG_6303](https://user-images.githubusercontent.com/27101659/185025712-c71ba9a7-9490-43d1-af0b-1eb3b090ed0f.png)

FLIPPED:
![IMG_6304](https://user-images.githubusercontent.com/27101659/185025644-f540c91c-cf61-49ae-9af3-8753a351fb28.png)

Since the recipes are flipped, the middle recipe produces a little bit less of the side products due to that flip. But all of the main required (iron-related) ingredients still have the same amount. So it can be confirmed that it is flipped correctly.

Of course, this will cause problems to existed saves that already set up their processing farm. So it is recommended to add this on with some other big contents update, such as the public release of PYAE.