### PR TITLE
Miners no longer take simik related modules

### DIFF
--- a/prototypes/buildings/aluminium-mine.lua
+++ b/prototypes/buildings/aluminium-mine.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 2
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/chromium-mine.lua
+++ b/prototypes/buildings/chromium-mine.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source =
     {
       type = "burner",

--- a/prototypes/buildings/coal-mine.lua
+++ b/prototypes/buildings/coal-mine.lua
@@ -57,7 +57,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/copper-mine.lua
+++ b/prototypes/buildings/copper-mine.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/iron-mine.lua
+++ b/prototypes/buildings/iron-mine.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/lead-mine.lua
+++ b/prototypes/buildings/lead-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/nexelit-mine.lua
+++ b/prototypes/buildings/nexelit-mine.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/nickel-mine.lua
+++ b/prototypes/buildings/nickel-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/phosphate-mine-02.lua
+++ b/prototypes/buildings/phosphate-mine-02.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/quartz-mine.lua
+++ b/prototypes/buildings/quartz-mine.lua
@@ -57,7 +57,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/salt-mine.lua
+++ b/prototypes/buildings/salt-mine.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 10,
     energy_source =
     {

--- a/prototypes/buildings/tin-mine.lua
+++ b/prototypes/buildings/tin-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/titanium-mine.lua
+++ b/prototypes/buildings/titanium-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {

--- a/prototypes/buildings/uranium-mine.lua
+++ b/prototypes/buildings/uranium-mine.lua
@@ -56,7 +56,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 15,
     energy_source =
     {

--- a/prototypes/buildings/zinc-mine.lua
+++ b/prototypes/buildings/zinc-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 20,
     energy_source =
     {


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.

Heads-up: I noticed that the titanium mine can't use speed modules as the only such mine, so I corrected that. Hope that's OK.