### PR TITLE
Fix starting ores for MediumPy.

### DIFF
--- a/prototypes/ores/aluminium.lua
+++ b/prototypes/ores/aluminium.lua
@@ -13,8 +13,6 @@ DATA {
     name = "ore-aluminium"
 }
 
-local starting_area = mods["pyalienlife"] and true or false
-
 ENTITY {
     type = "resource",
     name = "ore-aluminium",
@@ -42,7 +40,7 @@ ENTITY {
         order = "b",
         base_density = 10,
         base_spots_per_km2 = 1.25,
-        has_starting_area_placement = starting_area,
+        has_starting_area_placement = true,
         random_spot_size_minimum = 2,
         random_spot_size_maximum = 4,
         regular_rq_factor_multiplier = 1,

--- a/prototypes/ores/quartz.lua
+++ b/prototypes/ores/quartz.lua
@@ -38,7 +38,7 @@ ENTITY {
         order = "b",
         base_density = 10,
         base_spots_per_km2 = 1.25,
-        has_starting_area_placement = true,
+        has_starting_area_placement = not mods["pyalienlife"],
         random_spot_size_minimum = 2,
         random_spot_size_maximum = 4,
         regular_rq_factor_multiplier = 1,

--- a/prototypes/ores/tin.lua
+++ b/prototypes/ores/tin.lua
@@ -40,7 +40,7 @@ ENTITY {
         order = "b",
         base_density = 10,
         base_spots_per_km2 = 1.25,
-        has_starting_area_placement = true,
+        has_starting_area_placement = not mods["pyalienlife"],
         random_spot_size_minimum = 2,
         random_spot_size_maximum = 4,
         regular_rq_factor_multiplier = 1,


### PR DESCRIPTION
PyRO introduces tin for science buildings and quarts for the science packs. Both should therefore be starting ores. You also need aluminium for the car, so it should also be a starting ore.

PyAL makes planter boxes for automation science, and you can get the car with them, so tin and quartz no longer need to be starting ores. Aluminium still needs to be a starting ore, as it's still needed for the car.

RSO is also misconfigured with respect to these starting ores. I guess I'll open a ticket on their page to resolve this or something.

Resolves pyanodon/pybugreports#133