### PR TITLE
Added Salt Mine circuit connections

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -5,6 +5,8 @@ require("prototypes/recipe-categories")
 
 require('prototypes/items/items')
 
+require('prototypes/circuit-connector-definitions')
+
 if mods["pyalienlife"] then
     require('prototypes/items/pyalienlife-items')
 end

--- a/prototypes/buildings/salt-mine.lua
+++ b/prototypes/buildings/salt-mine.lua
@@ -86,13 +86,9 @@ ENTITY {
         width = 12,
         height = 12
     },
-
-    require ("__pyrawores__/prototypes/circuit-connector-definitions-pyro"),
-
-    circuit_wire_connection_points = salt_mine_connector_definitions.points,
-    circuit_connector_sprites = salt_mine_connector_definitions.sprites,
+    circuit_wire_connection_points = circuit_connector_definitions["salt-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["salt-mine"].sprites,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
-
     animations = {
         layers = {
             {

--- a/prototypes/buildings/salt-mine.lua
+++ b/prototypes/buildings/salt-mine.lua
@@ -86,6 +86,13 @@ ENTITY {
         width = 12,
         height = 12
     },
+
+    require ("__pyrawores__/prototypes/circuit-connector-definitions-pyro"),
+
+    circuit_wire_connection_points = salt_mine_connector_definitions.points,
+    circuit_connector_sprites = salt_mine_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/circuit-connector-definitions-pyro.lua
+++ b/prototypes/circuit-connector-definitions-pyro.lua
@@ -1,0 +1,10 @@
+salt_mine_connector_definitions = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false }, 
+    { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false },
+    { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false },
+    { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false }
+  }
+)

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -1,4 +1,9 @@
-salt_mine_connector_definitions = circuit_connector_definitions.create
+-- Adds circuit connection definitions for PyRO entities to the pre-existing global table
+-- for base-game implementation details, see https://github.com/wube/factorio-data/blob/ed3d12197fbbe63fcd19c0eb23bc826cea44410f/core/lualib/circuit-connector-sprites.lua#L101
+-- variation counts from 0 (Python-like).
+
+
+circuit_connector_definitions["salt-mine"] = circuit_connector_definitions.create
 (
   universal_connector_template,
   {--Directions are up, right, down, left.


### PR DESCRIPTION
This PR adds circuit connectivity to the Salt Mine for resource level output. This pulls definitions from a new `circuit-connector-definitions` file, as used in some of the other pY repos.