### PR TITLE
Circuit connections for pY RO Big Mines

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.4.16
+Date: When it's done
+  Changes:
+    - Added circuit connectivity to big mines (credit: JStMorgan) (https://github.com/pyanodon/pybugreports/issues/415)
+---------------------------------------------------------------------------------------------------
 Version: 2.4.15
 Date: 2024-3-24
   Changes:

--- a/prototypes/buildings/aluminium-mine.lua
+++ b/prototypes/buildings/aluminium-mine.lua
@@ -119,6 +119,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["aluminium-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["aluminium-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/chromium-mine.lua
+++ b/prototypes/buildings/chromium-mine.lua
@@ -71,6 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["chromium-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["chromium-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/coal-mine.lua
+++ b/prototypes/buildings/coal-mine.lua
@@ -97,6 +97,9 @@ ENTITY {
         width = 12,
         height = 12,
     },
+    circuit_wire_connection_points = circuit_connector_definitions["coal-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["coal-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/copper-mine.lua
+++ b/prototypes/buildings/copper-mine.lua
@@ -72,6 +72,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["copper-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["copper-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/iron-mine.lua
+++ b/prototypes/buildings/iron-mine.lua
@@ -72,6 +72,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["iron-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["iron-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/lead-mine.lua
+++ b/prototypes/buildings/lead-mine.lua
@@ -71,6 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["lead-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["lead-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/nexelit-mine.lua
+++ b/prototypes/buildings/nexelit-mine.lua
@@ -106,6 +106,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["nexelit-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["nexelit-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/nickel-mine.lua
+++ b/prototypes/buildings/nickel-mine.lua
@@ -71,6 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["nickel-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["nickel-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/phosphate-mine-02.lua
+++ b/prototypes/buildings/phosphate-mine-02.lua
@@ -71,6 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["phosphate-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["phosphate-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/quartz-mine.lua
+++ b/prototypes/buildings/quartz-mine.lua
@@ -83,6 +83,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["quartz-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["quartz-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/tin-mine.lua
+++ b/prototypes/buildings/tin-mine.lua
@@ -71,6 +71,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["tin-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["tin-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/titanium-mine.lua
+++ b/prototypes/buildings/titanium-mine.lua
@@ -72,6 +72,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["titanium-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["titanium-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/uranium-mine.lua
+++ b/prototypes/buildings/uranium-mine.lua
@@ -83,6 +83,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["uranium-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["uranium-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/zinc-mine.lua
+++ b/prototypes/buildings/zinc-mine.lua
@@ -72,6 +72,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["zinc-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["zinc-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -2,6 +2,115 @@
 -- for base-game implementation details, see https://github.com/wube/factorio-data/blob/ed3d12197fbbe63fcd19c0eb23bc826cea44410f/core/lualib/circuit-connector-sprites.lua#L101
 -- variation counts from 0 (Python-like).
 
+circuit_connector_definitions["aluminium-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 1, main_offset = util.by_pixel(150, 85), shadow_offset = util.by_pixel(160, 90), show_shadow = false }, 
+    { variation = 1, main_offset = util.by_pixel(150, 85), shadow_offset = util.by_pixel(160, 90), show_shadow = false },
+    { variation = 1, main_offset = util.by_pixel(150, 85), shadow_offset = util.by_pixel(160, 90), show_shadow = false },
+    { variation = 1, main_offset = util.by_pixel(150, 85), shadow_offset = util.by_pixel(160, 90), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["chromium-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 26, main_offset = util.by_pixel(125, -130), shadow_offset = util.by_pixel(135, -125), show_shadow = false }, 
+    { variation = 26, main_offset = util.by_pixel(125, -130), shadow_offset = util.by_pixel(135, -125), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(125, -130), shadow_offset = util.by_pixel(135, -125), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(125, -130), shadow_offset = util.by_pixel(135, -125), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["coal-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 2, main_offset = util.by_pixel(115, -50), shadow_offset = util.by_pixel(125, -45), show_shadow = false }, 
+    { variation = 2, main_offset = util.by_pixel(115, -50), shadow_offset = util.by_pixel(125, -45), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(115, -50), shadow_offset = util.by_pixel(125, -45), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(115, -50), shadow_offset = util.by_pixel(125, -45), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["copper-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 2, main_offset = util.by_pixel(-167, 92), shadow_offset = util.by_pixel(-157, 97), show_shadow = false }, 
+    { variation = 2, main_offset = util.by_pixel(-167, 92), shadow_offset = util.by_pixel(-157, 97), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(-167, 92), shadow_offset = util.by_pixel(-157, 97), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(-167, 92), shadow_offset = util.by_pixel(-157, 97), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["iron-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 1, main_offset = util.by_pixel(90, 55), shadow_offset = util.by_pixel(100, 60), show_shadow = false }, 
+    { variation = 1, main_offset = util.by_pixel(90, 55), shadow_offset = util.by_pixel(100, 60), show_shadow = false },
+    { variation = 1, main_offset = util.by_pixel(90, 55), shadow_offset = util.by_pixel(100, 60), show_shadow = false },
+    { variation = 1, main_offset = util.by_pixel(90, 55), shadow_offset = util.by_pixel(100, 60), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["lead-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 18, main_offset = util.by_pixel(118, 142), shadow_offset = util.by_pixel(128, 147), show_shadow = false }, 
+    { variation = 18, main_offset = util.by_pixel(118, 142), shadow_offset = util.by_pixel(128, 147), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(118, 142), shadow_offset = util.by_pixel(128, 147), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(118, 142), shadow_offset = util.by_pixel(128, 147), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["nexelit-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 27, main_offset = util.by_pixel(-133, 102), shadow_offset = util.by_pixel(-123, 107), show_shadow = false }, 
+    { variation = 27, main_offset = util.by_pixel(-133, 102), shadow_offset = util.by_pixel(-123, 107), show_shadow = false },
+    { variation = 27, main_offset = util.by_pixel(-133, 102), shadow_offset = util.by_pixel(-123, 107), show_shadow = false },
+    { variation = 27, main_offset = util.by_pixel(-133, 102), shadow_offset = util.by_pixel(-123, 107), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["nickel-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 2, main_offset = util.by_pixel(-150, 130), shadow_offset = util.by_pixel(-140, 135), show_shadow = false }, 
+    { variation = 2, main_offset = util.by_pixel(-150, 130), shadow_offset = util.by_pixel(-140, 135), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(-150, 130), shadow_offset = util.by_pixel(-140, 135), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(-150, 130), shadow_offset = util.by_pixel(-140, 135), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["phosphate-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 18, main_offset = util.by_pixel(72, 185), shadow_offset = util.by_pixel(82, 190), show_shadow = false }, 
+    { variation = 18, main_offset = util.by_pixel(72, 185), shadow_offset = util.by_pixel(82, 190), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(72, 185), shadow_offset = util.by_pixel(82, 190), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(72, 185), shadow_offset = util.by_pixel(82, 190), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["quartz-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 10, main_offset = util.by_pixel(90, 65), shadow_offset = util.by_pixel(100, 70), show_shadow = false }, 
+    { variation = 10, main_offset = util.by_pixel(90, 65), shadow_offset = util.by_pixel(100, 70), show_shadow = false },
+    { variation = 10, main_offset = util.by_pixel(90, 65), shadow_offset = util.by_pixel(100, 70), show_shadow = false },
+    { variation = 10, main_offset = util.by_pixel(90, 65), shadow_offset = util.by_pixel(100, 70), show_shadow = false }
+  }
+)
 
 circuit_connector_definitions["salt-mine"] = circuit_connector_definitions.create
 (
@@ -11,5 +120,49 @@ circuit_connector_definitions["salt-mine"] = circuit_connector_definitions.creat
     { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false },
     { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false },
     { variation = 25, main_offset = util.by_pixel(135, -105), shadow_offset = util.by_pixel(145, -100), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["tin-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 7, main_offset = util.by_pixel(107, -7), shadow_offset = util.by_pixel(117, -2), show_shadow = false }, 
+    { variation = 7, main_offset = util.by_pixel(107, -7), shadow_offset = util.by_pixel(117, -2), show_shadow = false },
+    { variation = 7, main_offset = util.by_pixel(107, -7), shadow_offset = util.by_pixel(117, -2), show_shadow = false },
+    { variation = 7, main_offset = util.by_pixel(107, -7), shadow_offset = util.by_pixel(117, -2), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["titanium-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 2, main_offset = util.by_pixel(188, 170), shadow_offset = util.by_pixel(198, 175), show_shadow = false }, 
+    { variation = 2, main_offset = util.by_pixel(188, 170), shadow_offset = util.by_pixel(198, 175), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(188, 170), shadow_offset = util.by_pixel(198, 175), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(188, 170), shadow_offset = util.by_pixel(198, 175), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["uranium-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 26, main_offset = util.by_pixel(133, 72), shadow_offset = util.by_pixel(143, 77), show_shadow = false }, 
+    { variation = 26, main_offset = util.by_pixel(133, 72), shadow_offset = util.by_pixel(143, 77), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(133, 72), shadow_offset = util.by_pixel(143, 77), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(133, 72), shadow_offset = util.by_pixel(143, 77), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["zinc-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 18, main_offset = util.by_pixel(137, 137), shadow_offset = util.by_pixel(147, 142), show_shadow = false }, 
+    { variation = 18, main_offset = util.by_pixel(137, 137), shadow_offset = util.by_pixel(147, 142), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(137, 137), shadow_offset = util.by_pixel(147, 142), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(137, 137), shadow_offset = util.by_pixel(147, 142), show_shadow = false }
   }
 )


### PR DESCRIPTION
Addresses pyanodon/pybugreports#415 .
This is the last set of circuit connectivity for pY Miners, covering the big versions of the Aluminium, Chromium, Coal, Copper, Iron, Lead, Nexelit, Nickel, Phosphate, Quartz, Tin, Titanium, Uranium and Zinc mines.