### PR TITLE
fix: add main_product for syngas2

### DIFF
--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -133,6 +133,7 @@ RECIPE {
         {type = "fluid", name = "tar",    amount = 30},
         {type = "item",  name = "ash",    amount = 1}
     },
+    main_product = "syngas",
     icon = "__pycoalprocessinggraphics__/graphics/icons/syngas.png",
     icon_size = 32,
     subgroup = "py-syngas",


### PR DESCRIPTION
Fixes https://github.com/pyanodon/pybugreports/issues/793. Syngas2 is missing a main product and so won't show up as a signal.